### PR TITLE
Use patched xvfb wrapper and disable flock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ MAINTAINER Flywheel <support@flywheel.io>
 # Install jq to parse the JSON config file
 RUN apt-get update && apt-get -y install jq zip
 
+# Install patched version of xvfbwrapper
+RUN pip install -q https://github.com/ehlertjd/xvfbwrapper/releases/download/0.2.9.post1/xvfbwrapper-0.2.9.post1-py2.py3-none-any.whl
+
 # Make directory for flywheel spec (v0)
 ENV FLYWHEEL /flywheel/v0
 RUN mkdir -p ${FLYWHEEL}
@@ -16,6 +19,8 @@ COPY manifest.json ${FLYWHEEL}/manifest.json
 # ENV preservation for Flywheel Engine
 RUN env -u HOSTNAME -u PWD | \
   awk -F = '{ print "export " $1 "=\"" $2 "\"" }' > ${FLYWHEEL}/docker-env.sh
+
+RUN echo "export XVFB_WRAPPER_SOFT_FILE_LOCK=1" >> ${FLYWHEEL}/docker-env.sh
 
 # Set the entrypoint
 ENTRYPOINT ["/flywheel/v0/run"]

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
     }
   },
   "custom": {
-    "docker-image": "flywheel/mriqc:v0.4.0"
+    "docker-image": "flywheel/mriqc:v0.4.1"
   },
   "description": "MRIQC (v0.10.1) extracts no-reference IQMs (image quality metrics) from structural (T1w and T2w) and functional MRI (magnetic resonance imaging) data. Note, this gear only supports the generation of individual scan reports; group reports are not generated. Also note, for the auto-detection config option to work for this gear, the follow gears must be run beforehand: (1) dicom-mr-classifier then (2) dcm2niix (version 0.3.1 or higher).",
   "inputs": {
@@ -50,5 +50,5 @@
   "name": "mriqc",
   "source": "https://github.com/flywheel-apps/mriqc",
   "url": "https://github.com/poldracklab/mriqc",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }


### PR DESCRIPTION
This PR is to fix the intermittent `No locks available` error on NFS:

```python
Traceback (most recent call last):
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/plugins/multiproc.py", line 62, in run_node
    result['result'] = node.run(updatehash=updatehash)
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/engine/nodes.py", line 443, in run
    result = self._run_interface(execute=True)
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/engine/nodes.py", line 520, in _run_interface
    return self._run_command(execute)
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/engine/nodes.py", line 596, in _run_command
    result = self._interface.run()
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/interfaces/base/core.py", line 459, in run
    env['DISPLAY'] = config.get_display()
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/utils/config.py", line 333, in get_display
    self._display.start()
  File "/usr/local/miniconda/lib/python3.6/site-packages/xvfbwrapper.py", line 64, in start
    self.new_display = self._get_next_unused_display()
  File "/usr/local/miniconda/lib/python3.6/site-packages/xvfbwrapper.py", line 126, in _get_next_unused_display
    fcntl.LOCK_EX | fcntl.LOCK_NB)
OSError: [Errno 37] No locks available
```

The fix is done by installing a [patched xvfbwrapper](https://github.com/ehlertjd/xvfbwrapper/commit/fd7bc7d41b583eabc577ff8c1b5406b62f0e84cf), and setting the `XVFB_WRAPPER_SOFT_FILE_LOCK` environment variable to use soft file locking rather than `flock`. 

I've tested the new container against a single anatomy_T1w dataset, but didn't have an NFS to reproduce / test the specific fix.
